### PR TITLE
Adapt to new rhel image nodejs installation

### DIFF
--- a/dist/rails/nodejs/Dockerfile
+++ b/dist/rails/nodejs/Dockerfile
@@ -1,4 +1,5 @@
 FROM centos/ruby-22-centos7
+
 # ABOUT
 # A Rails/webpack frontend image to be used with S2I.
 #
@@ -80,14 +81,15 @@ RUN \
 # See https://github.com/sclorg/rhscl-dockerfiles/issues/26
 ENV BUNDLE_WITHOUT=development:test
 
+
 USER root
 
 ADD /contrib/bin/install-nodejs $STI_SCRIPTS_PATH
 
 RUN \
     # Remove nodejs provided by centos ruby22 base image
-    yum remove -y nodejs010* && \
-    sed -e "s/nodejs010//g" -i /opt/app-root/etc/scl_enable && \
+    yum remove -y rh-nodejs* && \
+    sed -e "s/ \$NODEJS_SCL//g" -i /opt/app-root/etc/scl_enable && \
     # Install node
     scl enable rh-ruby22 $STI_SCRIPTS_PATH/install-nodejs && \
     # Install yarn (install without dep check since nodejs is installed via tar)
@@ -95,6 +97,7 @@ RUN \
     rpm -Uvh --nodeps $(repoquery --location yarn)
 
 ENV PATH="/opt/nodejs/bin:${PATH}"
+
 
 # Add S2I scripts.
 USER root
@@ -105,8 +108,10 @@ ADD /s2i/* $STI_SCRIPTS_PATH/
 
 RUN chmod ugo+x $STI_SCRIPTS_PATH/*
 
+
 USER 1001
 
 # ENTRYPOINT
 
 CMD $STI_SCRIPTS_PATH/run-httpd.sh
+

--- a/dist/rails/nodejs/nodejs6/Dockerfile
+++ b/dist/rails/nodejs/nodejs6/Dockerfile
@@ -1,4 +1,5 @@
 FROM centos/ruby-22-centos7
+
 # ABOUT
 # A Rails/webpack frontend image to be used with S2I.
 #
@@ -80,14 +81,15 @@ RUN \
 # See https://github.com/sclorg/rhscl-dockerfiles/issues/26
 ENV BUNDLE_WITHOUT=development:test
 
+
 USER root
 
 ADD /contrib/bin/install-nodejs $STI_SCRIPTS_PATH
 
 RUN \
     # Remove nodejs provided by centos ruby22 base image
-    yum remove -y nodejs010* && \
-    sed -e "s/nodejs010//g" -i /opt/app-root/etc/scl_enable && \
+    yum remove -y rh-nodejs* && \
+    sed -e "s/ \$NODEJS_SCL//g" -i /opt/app-root/etc/scl_enable && \
     # Install node
     scl enable rh-ruby22 $STI_SCRIPTS_PATH/install-nodejs && \
     # Install yarn (install without dep check since nodejs is installed via tar)
@@ -95,6 +97,7 @@ RUN \
     rpm -Uvh --nodeps $(repoquery --location yarn)
 
 ENV PATH="/opt/nodejs/bin:${PATH}"
+
 
 # Add S2I scripts.
 USER root
@@ -105,8 +108,10 @@ ADD /s2i/* $STI_SCRIPTS_PATH/
 
 RUN chmod ugo+x $STI_SCRIPTS_PATH/*
 
+
 USER 1001
 
 # ENTRYPOINT
 
 CMD $STI_SCRIPTS_PATH/run-httpd.sh
+

--- a/dist/rails/pure/Dockerfile
+++ b/dist/rails/pure/Dockerfile
@@ -1,4 +1,5 @@
 FROM centos/ruby-22-centos7
+
 LABEL io.k8s.description="Base Image for Rails" \
       io.k8s.display-name="pitc-rails-bi" \
       io.openshift.expose-services="8080:http" \
@@ -82,6 +83,7 @@ RUN \
 # See https://github.com/sclorg/rhscl-dockerfiles/issues/26
 ENV BUNDLE_WITHOUT=development:test
 
+
 # Add S2I scripts.
 USER root
 
@@ -90,6 +92,7 @@ RUN mv $STI_SCRIPTS_PATH/run $STI_SCRIPTS_PATH/run_base
 ADD /s2i/* $STI_SCRIPTS_PATH/
 
 RUN chmod ugo+x $STI_SCRIPTS_PATH/*
+
 
 USER 1001
 

--- a/dist/rails/sphinx/Dockerfile
+++ b/dist/rails/sphinx/Dockerfile
@@ -1,7 +1,5 @@
 FROM centos/ruby-22-centos7
-      
-      
-      
+
 
 # ABOUT
 # A Rails image to be used with OpenShift S2I.
@@ -10,6 +8,7 @@ USER root
 
 ADD /contrib/bin/install-sphinx.sh $STI_SCRIPTS_PATH
 RUN scl enable rh-ruby22 $STI_SCRIPTS_PATH/install-sphinx.sh 
+
 USER root
 
 # SLOW STUFF
@@ -85,6 +84,7 @@ RUN \
 # See https://github.com/sclorg/rhscl-dockerfiles/issues/26
 ENV BUNDLE_WITHOUT=development:test
 
+
 # Add S2I scripts.
 USER root
 
@@ -93,6 +93,7 @@ RUN mv $STI_SCRIPTS_PATH/run $STI_SCRIPTS_PATH/run_base
 ADD /s2i/* $STI_SCRIPTS_PATH/
 
 RUN chmod ugo+x $STI_SCRIPTS_PATH/*
+
 
 USER 1001
 

--- a/dist/rails/sphinx/transifex/Dockerfile
+++ b/dist/rails/sphinx/transifex/Dockerfile
@@ -1,7 +1,5 @@
 FROM centos/ruby-22-centos7
-      
-      
-      
+
 
 # ABOUT
 # A Rails image to be used with OpenShift S2I.
@@ -10,6 +8,7 @@ USER root
 
 ADD /contrib/bin/install-sphinx.sh $STI_SCRIPTS_PATH
 RUN scl enable rh-ruby22 $STI_SCRIPTS_PATH/install-sphinx.sh 
+
 USER root
 
 # SLOW STUFF
@@ -84,10 +83,12 @@ RUN \
 # Workaround for base image: Do not install gems from development and test environments
 # See https://github.com/sclorg/rhscl-dockerfiles/issues/26
 ENV BUNDLE_WITHOUT=development:test
+
 USER root
 
 ADD /contrib/bin/install-transifex.sh $STI_SCRIPTS_PATH
 RUN scl enable rh-ruby22 $STI_SCRIPTS_PATH/install-transifex.sh 
+
 
 # Add S2I scripts.
 USER root
@@ -97,6 +98,7 @@ RUN mv $STI_SCRIPTS_PATH/run $STI_SCRIPTS_PATH/run_base
 ADD /s2i/* $STI_SCRIPTS_PATH/
 
 RUN chmod ugo+x $STI_SCRIPTS_PATH/*
+
 
 USER 1001
 

--- a/src/rails/_partials/_install_node_yarn.erb
+++ b/src/rails/_partials/_install_node_yarn.erb
@@ -4,8 +4,8 @@ ADD /contrib/bin/install-nodejs $STI_SCRIPTS_PATH
 
 RUN \
     # Remove nodejs provided by centos ruby22 base image
-    yum remove -y nodejs010* && \
-    sed -e "s/nodejs010//g" -i /opt/app-root/etc/scl_enable && \
+    yum remove -y rh-nodejs* && \
+    sed -e "s/ \$NODEJS_SCL//g" -i /opt/app-root/etc/scl_enable && \
     # Install node
     scl enable rh-ruby22 $STI_SCRIPTS_PATH/install-nodejs && \
     # Install yarn (install without dep check since nodejs is installed via tar)

--- a/src/rails/nodejs/nodejs6/_context/contrib/bin/install-nodejs
+++ b/src/rails/nodejs/nodejs6/_context/contrib/bin/install-nodejs
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 ARCH='x64'.freeze
-MAJOR_NODEJS_VERSION=8.freeze
+MAJOR_NODEJS_VERSION=6.freeze
 GITHUB_REPO_URL='https://github.com/nodejs/node.git'.freeze
 DOWNLOAD_BASE_URL='https://nodejs.org/dist'.freeze
 

--- a/test/test_app/frontend/config/build/build_frontend.sh
+++ b/test/test_app/frontend/config/build/build_frontend.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+cd $(dirname $0)
+
+node --version
+
+# Create fake build output for assemble script
+mkdir ../../dist
+touch ../../dist/app.js


### PR DESCRIPTION
Friends! `centos/ruby-22-centos6` has updated their default Node installation from `0.10` to `6.x.x`, this PR addresses these changes.